### PR TITLE
Add main_container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>Cortex</title>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width user-scalable=no" />
-<link rel="icon" href="/favicon.png">
-<link rel="stylesheet" href="/style.css">
-<link rel="manifest" href="/manifest.json">
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500" rel="stylesheet">
-<script src="/main.js" async onload="window['Main']()"></script>
-</head>
+  <head>
+  <title>Cortex</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width user-scalable=no" />
+  <link rel="icon" href="favicon.png">
+  <link rel="stylesheet" href="reset.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500" rel="stylesheet">
+  <script src="/main.js" async onload="window['Main']()"></script>
+  </head>
 <body>
+  <div class="main_container">
+  </div>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -37,7 +37,9 @@ function CreateControl(room_name, lights_on, brightness) {
 
 
 // -------------------------------------------------------------------------------------------------
-
+function GetMainContainer() {
+    return document.getElementsByClassName('main_container')[0];
+}
 
 function ProcessHue(response) {
     let items = JSON.parse(response);
@@ -46,7 +48,7 @@ function ProcessHue(response) {
         let lights_on = item.state.on;
         let brightness = Math.round(item.state.bri / 254 * 100);
         let control = CreateControl(item.name, lights_on, brightness);
-        document.body.appendChild(control);
+        GetMainContainer().appendChild(control);
     }
 }
 

--- a/reset.css
+++ b/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/style.css
+++ b/style.css
@@ -1,14 +1,17 @@
-* {
+.text {
     font-family: Montserrat, sans-serif;
     font-size: 14px;
-    border: 0;
-    margin: 0;
-    padding: 0;
 }
 
 html, body {
     height: 100%;
     overscroll-behavior: none;
+}
+
+div.main_container {
+  margin: 0 auto;
+  width: 400px;
+  max-width: 100%;
 }
 
 div.control {


### PR DESCRIPTION
This allows content have limited width and to be centered on a wider
screen (laptop/desktop), while it still fills the width of a narrower
screen (phone).

Drive-by: resources are relative to index.html (helps code navigation).

Drive-by: reset.css added to reset default CSS of browsers. (Ref:
https://speckyboy.com/cross-browser-css-styling-tips/)

Drive-by: font is added just to the .text class (font now works in
"Brave browser").

---

To test:
```
$ git clone git@github.com:smanilov/cortex.git /tmp/cortex
$ pushd /tmp/cortex && git checkout init-css && popd
$ python -m http.server 8080 -d /tmp/cortex
```
http://localhost:8080